### PR TITLE
Safeguard against type-incompatible member overwrites

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import * as u from "./util";
 export function C<
   BaseCtor extends Ctor,
   BaseInstance extends InstanceType<BaseCtor>,
-  Produce extends (define: Define<BaseInstance>, props: any) => u.AnyRecOr.Void,
+  Produce extends (define: Define<BaseInstance>, props: any) => (Partial<BaseInstance> & u.AnyRec) | void,
   Props extends Parameters<Produce>[1],
   AdditionalMembers extends ReturnType<Produce>
 >(
@@ -33,9 +33,7 @@ export function C<
       super(...(idOrUndef ? [parentOrProps, idOrUndef, propsForSuper] : [propsForSuper]));
       const define = Define(this as any);
       const produced = produce(define, props);
-      if (produced) {
-        Object.assign(this, produced);
-      }
+      produced && Object.assign(this, produced);
     }
   } as any;
 }

--- a/src/tests/overwrites.ts
+++ b/src/tests/overwrites.ts
@@ -1,0 +1,61 @@
+import {C} from "..";
+import * as cdk from "@aws-cdk/core";
+
+describe("Overwrites", () => {
+  it("Conflicting type fails", () => {
+    expect.assertions(0);
+
+    // @ts-expect-error
+    C(cdk.Stack, () => {
+      return {
+        environment: 123,
+      };
+    });
+  });
+
+  it("Compatible type succeeds", () => {
+    expect.assertions(0);
+
+    C(cdk.Stack, () => {
+      return {
+        environment: "hello",
+      };
+    });
+  });
+
+  it("Narrowing the chain", () => {
+    expect.assertions(0);
+
+    const StackA = C(cdk.Stack, () => {
+      return {
+        environment: "literal" as "literal" | undefined,
+      };
+    });
+
+    // @ts-expect-error
+    C(StackA, () => {
+      return {
+        environment: "something-else",
+      };
+    });
+
+    const StackB = C(StackA, () => {
+      return {
+        environment: "literal",
+      };
+    });
+
+    // @ts-expect-error
+    C(StackB, () => {
+      return {
+        environment: "yo",
+      };
+    });
+
+    C(StackA, () => {
+      return {
+        environment: undefined,
+      };
+    });
+  });
+});

--- a/src/util/in-rest.ts
+++ b/src/util/in-rest.ts
@@ -1,4 +1,4 @@
-import {AnyRecOr} from "./molecules";
+import {AnyRec} from "./molecules";
 
 export namespace InRest {
   export type Props<Props, EmptyIfUndef extends boolean = true> = Props extends undefined
@@ -7,7 +7,7 @@ export namespace InRest {
     ? [props?: Props]
     : [props: Props];
 
-  export type BasePropsOrMapper<P extends AnyRecOr.Undef, B extends AnyRecOr.Undef> = B extends undefined
+  export type BasePropsOrMapper<P extends AnyRec.Or.Undef, B extends AnyRec.Or.Undef> = B extends undefined
     ? []
     : undefined extends B
     ? P extends undefined

--- a/src/util/molecules.ts
+++ b/src/util/molecules.ts
@@ -1,5 +1,7 @@
-export type AnyRecOr<Or> = Record<PropertyKey, any> | Or;
-export namespace AnyRecOr {
-  export type Undef = AnyRecOr<undefined>;
-  export type Void = AnyRecOr<void>;
+export type AnyRec = Record<PropertyKey, any>;
+export namespace AnyRec {
+  export type Or<O> = AnyRec | O;
+  export namespace Or {
+    export type Undef = Or<void>;
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Refer to CONTRIBUTING.MD for more details: https://github.com/awslabs/concise-constructs/blob/master/CONTRIBUTING.md
-->

**Summary**:

Ensures that the types of members returned from `C` arg 1 do not conflict with the member types of the base class (arg 0). Given that `C` is creating a subclass of arg 0, it makes sense to abide by the rules of inheritance, and to allow type-compatible overwrites.

Follows suit with this:

Produces a type-error:

```ts
class A {
    something(_0: string): number {
        return 1.618;
    }
}

class B extends A {
    something(): boolean {
//  ~~~~~~~~~
//  ^
//  Property 'something' in type 'B' is not assignable to the same property in base type 'A'.
        return true;
    }
}
```

We can however overwrite `something` if the type is compatible with that of its parent.

```diff
class B extends A {
-    something(): boolean {
+    something(): number {
-       return true;
+       return 212;
    }
}
```

Please verify the following:

- [x] Your PR is up-to-date with the `main` branch
- [x] There are new or updated tests validating the change
- [x] You have successfully run `npm run test` locally
- [x] If the API is changed, there is documentation reflecting the change.
